### PR TITLE
Removed verbose log statement on reading packets

### DIFF
--- a/ipproxy.go
+++ b/ipproxy.go
@@ -197,7 +197,6 @@ func (p *proxy) readDownstreamPackets(wg *sync.WaitGroup) (finalErr error) {
 			}
 			return errors.New("Unexpected error reading from downstream: %v", err)
 		}
-		log.Debug("Read packet")
 		raw := b[:n]
 		pkt, err := parseIPPacket(raw)
 		if err != nil {


### PR DESCRIPTION
I noticed a lot of these log statements, which pollutes the log and probably hurts performance a bit.